### PR TITLE
Update guesser to be concordant with Faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "doctrine/inflector": "^1.1",
         "api-platform/core": "~1.1@beta",
         "ramsey/uuid": "^3.2",
-        "fzaninotto/faker": "^1.5"
+        "fzaninotto/faker": "^1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "<5.0",

--- a/src/Faker/Guesser/Guesser.php
+++ b/src/Faker/Guesser/Guesser.php
@@ -129,11 +129,12 @@ class Guesser extends Name
     }
 
     /**
-     * @param string $name
+     * @param string   $name
+     * @param int|null $size Length of field, if known
      *
      * @return mixed
      */
-    public function guessFormat($name)
+    public function guessFormat($name, $size = null)
     {
         if (null !== ($value = parent::guessFormat($name))) {
             return $value;


### PR DESCRIPTION
Faker dependency is set to allow for 1.6 version which has a new param (size) for guessFormat.
I propose to update the definition or you could also fix the version. What do you think @vincentchalamon 
